### PR TITLE
Remove custom logging at /vagrant/app/logs/.

### DIFF
--- a/provisioning/app/dev.support.surfconext.nl.conf
+++ b/provisioning/app/dev.support.surfconext.nl.conf
@@ -16,7 +16,4 @@ NameVirtualHost *:443
         Order allow,deny
         Allow from All
     </Directory>
-
-    ErrorLog /vagrant/app/logs/apache-error.log
-    CustomLog /vagrant/app/logs/apache-access.log combined
 </VirtualHost>


### PR DESCRIPTION
Apache wouldn't boot because of this as the share would not be available when it wants to start.