### PR TITLE
Fix misspelled attribute names.

### DIFF
--- a/app/Resources/attributes.json
+++ b/app/Resources/attributes.json
@@ -51,7 +51,7 @@
     "id": "organizationType",
     "friendlyName": "Organization Type",
     "urns": [
-      "urn:mace:terena.org:attribute-def:schacHomeOrganizationType ",
+      "urn:mace:terena.org:attribute-def:schacHomeOrganizationType",
       "urn:oid:1.3.6.1.4.1.25178.1.2.10"
     ]
   },
@@ -115,7 +115,7 @@
     "id": "personalCode",
     "friendlyName": "Employee\/student number",
     "urns": [
-      "urn:mace:dir:attribute-def:schacPersonalUniqueCode",
+      "urn:schac:attribute-def:schacPersonalUniqueCode",
       "urn:oid:1.3.6.1.4.1.1466.155.121.1.15"
     ]
   }

--- a/src/AppBundle/Metadata/MetadataUtil.php
+++ b/src/AppBundle/Metadata/MetadataUtil.php
@@ -98,7 +98,7 @@ abstract class MetadataUtil
             ),
             'organizationType'   => array(
                 'name'         => array(
-                    'urn:mace:terena.org:attribute-def:schacHomeOrganizationType ',
+                    'urn:mace:terena.org:attribute-def:schacHomeOrganizationType',
                     'urn:oid:1.3.6.1.4.1.25178.1.2.10'
                 ),
                 'friendlyName' => 'Organization Type'
@@ -154,7 +154,7 @@ abstract class MetadataUtil
             ),
             'personalCode'       => array(
                 'name'         => array(
-                    'urn:mace:dir:attribute-def:schacPersonalUniqueCode',
+                    'urn:schac:attribute-def:schacPersonalUniqueCode',
                     'urn:oid:1.3.6.1.4.1.1466.155.121.1.15'
                 ),
                 'friendlyName' => 'Employee/student number'

--- a/src/AppBundle/Tests/Metadata/Fixtures/metadata.xml
+++ b/src/AppBundle/Tests/Metadata/Fixtures/metadata.xml
@@ -86,7 +86,7 @@
             <md:RequestedAttribute Name="urn:oid:2.16.840.1.113730.3.1.39" isRequired="true"/>
             <md:RequestedAttribute Name="urn:mace:dir:attribute-def:eduPersonScopedAffiliation" isRequired="true"/>
             <md:RequestedAttribute Name="urn:oid:1.3.6.1.4.1.5923.1.5.1.1" isRequired="true"/>
-            <md:RequestedAttribute Name="urn:mace:dir:attribute-def:schacPersonalUniqueCode" isRequired="true"/>
+            <md:RequestedAttribute Name="urn:schac:attribute-def:schacPersonalUniqueCode" isRequired="true"/>
         </md:AttributeConsumingService>
     </md:SPSSODescriptor>
     <md:ContactPerson contactType="technical">

--- a/src/AppBundle/Tests/Metadata/Fixtures/metadata_lean.xml
+++ b/src/AppBundle/Tests/Metadata/Fixtures/metadata_lean.xml
@@ -83,7 +83,7 @@
             <md:RequestedAttribute Name="urn:oid:0.9.2342.19200300.100.1.1" isRequired="true"/>
             <md:RequestedAttribute Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" isRequired="true"/>
             <md:RequestedAttribute Name="urn:oid:2.16.840.1.113730.3.1.39" isRequired="true"/>
-            <md:RequestedAttribute Name="urn:mace:dir:attribute-def:schacPersonalUniqueCode" isRequired="true"/>
+            <md:RequestedAttribute Name="urn:schac:attribute-def:schacPersonalUniqueCode" isRequired="true"/>
         </md:AttributeConsumingService>
     </md:SPSSODescriptor>
     <md:ContactPerson contactType="technical">

--- a/src/AppBundle/Tests/Metadata/GeneratorTest.php
+++ b/src/AppBundle/Tests/Metadata/GeneratorTest.php
@@ -176,7 +176,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
 
         // Removed existing attribute based on first key
         $this->assertNotContains(
-            'md:RequestedAttribute Name="urn:mace:dir:attribute-def:schacPersonalUniqueCode"',
+            'md:RequestedAttribute Name="urn:schac:attribute-def:schacPersonalUniqueCode"',
             $xml
         );
         $this->assertNotContains('md:RequestedAttribute Name="urn:oid:1.3.6.1.4.1.1466.155.121.1.15"', $xml);


### PR DESCRIPTION
Remove space from schacHomeOrganizationType and move schacPersonalUniqueCode
to the right namespace.